### PR TITLE
Fixes License

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "minify-css": "touch public/css/combined.min.css; cleancss -o public/css/combined.min.css public/css/combined.css"
   },
   "author": "",
-  "license": "ISC",
+  "license": "CC-BY-3.0",
   "dependencies": {
     "async": "^2.0.0",
     "babel": "^6.5.2",


### PR DESCRIPTION
In `package.json` the license is currently listed as ISC but the `LICENSE` file is the Creative Commons 3 License.  This adds the correct license identifier according to: https://spdx.org/licenses/